### PR TITLE
Change http_upload_file to use HTTPSConnection if url is https

### DIFF
--- a/example-settings.json
+++ b/example-settings.json
@@ -1,6 +1,6 @@
 {
-    "destination_server": "legacydev.cnx.org",
-    "source_server": "legacy.cnx.org",
+    "destination_server": "https://legacydev.cnx.org",
+    "source_server": "https://legacy.cnx.org",
     "destination_credentials": "user2:user2password",
 
     "authors":["user2"],

--- a/lib/http_util.py
+++ b/lib/http_util.py
@@ -120,7 +120,10 @@ def http_upload_file(xmlfile, zipfile, url, credentials, mpartfilename='tmp'):
 
     signal.signal(signal.SIGALRM, handle_timeout)
     signal.alarm(timeout)
-    connection = httplib.HTTPConnection(req.get_host())
+    if url.startswith('https://'):
+        connection = httplib.HTTPSConnection(req.get_host())
+    else:
+        connection = httplib.HTTPConnection(req.get_host())
     connection.request('POST', req.get_selector(), open(abs_path), headers)
     response = connection.getresponse()
     signal.alarm(0)


### PR DESCRIPTION
Since the beginning of October 2017, the cnx sites are using https only,
all http requests are redirected.  When this tool was written, the
default was to use http, but now we need to change the example settings
to use https.

---

Ryan was having problems using the content copy tool on content01.cnx.org, this change worked for her.